### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-yaml.yml
+++ b/.github/workflows/update-yaml.yml
@@ -1,5 +1,8 @@
 name: Update Yaml files
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/all-in-one/security/code-scanning/22](https://github.com/Fadil369/all-in-one/security/code-scanning/22)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. For this workflow:
- The `contents: write` permission is needed for the `peter-evans/create-pull-request` action to create pull requests.
- Other permissions should be set to `read` or omitted if not required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`update-yaml`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
