### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: dependency-updates
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/all-in-one/security/code-scanning/1](https://github.com/Fadil369/all-in-one/security/code-scanning/1)

To fix the problem, add an explicit `permissions` key to the workflow. Since the workflow needs to create pull requests (using `peter-evans/create-pull-request`), it must grant `contents: read` and `pull-requests: write` permissions. This should be added at the workflow level (top-level, after the `name` and before `on` blocks), so all jobs inherit these permissions, unless more granular control is desired. No changes are needed to the actions or steps themselves. Only the YAML at the top of `.github/workflows/dependency-updates.yml` needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
