### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/json-validator.yml
+++ b/.github/workflows/json-validator.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Json Validator
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/all-in-one/security/code-scanning/5](https://github.com/Fadil369/all-in-one/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow configuration to explicitly restrict the `GITHUB_TOKEN` permissions. The best way is to add this block at the workflow root, so it applies to all jobs unless overridden. Based on the workflow's functionality (checkout code and validate JSON files), only `contents: read` permission is required. The change should be made at the top of `.github/workflows/json-validator.yml`, below the `name:` declaration and before the `on:` block. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
