### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI/CD Workflow
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/all-in-one/security/code-scanning/15](https://github.com/Fadil369/all-in-one/security/code-scanning/15)

To fix the problem, explicitly set the `permissions` key at the root of the workflow (top-level, just below `name:` or above `on:`) to assign the least privilege required for all jobs. Since most jobs only need to check out code, `contents: read` is usually sufficient. If the `build-docker` job pushes images to DockerHub but does not push to GitHub Packages, `contents: read` remains sufficient. If any job did require more (e.g., to write to GitHub Packages or create releases), you would add those scopes. The explicit block should be placed at the top of `.github/workflows/main.yml` (for workflow-wide effect). No code functionality is changed; it simply restricts what the GITHUB_TOKEN can do during these jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
