### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/community-containers.yml
+++ b/.github/workflows/community-containers.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Validate community containers
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/all-in-one/security/code-scanning/3](https://github.com/Fadil369/all-in-one/security/code-scanning/3)

To fix this issue, you should add a `permissions` block specifying the least privilege needed for the workflow. Since the workflow only checks out code and runs local validations, it only needs read access to the repository contents. You should add `permissions: contents: read` at the top level of the workflow (just below the `name` field, but above `on:`), so it applies to all jobs in the workflow. No other privileges are required for this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
