### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,5 +1,8 @@
 name: 'Codespell'
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/all-in-one/security/code-scanning/2](https://github.com/Fadil369/all-in-one/security/code-scanning/2)

To fix this problem, we need to add an explicit `permissions` block in the workflow YAML to restrict access for the GITHUB_TOKEN to only the permissions needed. Since the codespell job only checks code for spelling errors and does not need to write to the repository or interact with pull requests/issues, the least privilege permission required is `contents: read`. 

The best way to fix this is to add the following block at the root of the workflow file (above `jobs:`), which will apply to all jobs in the workflow that do not have their own `permissions` block:
```yaml
permissions:
  contents: read
```
No changes to imports, methods, or definitions are required—just an update to the YAML file to insert this block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
